### PR TITLE
Add .formatter.exs and run mix format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,4 +14,5 @@ jobs:
       - run: mix local.rebar --force
       - run: mix local.hex --force
       - run: mix deps.get
+      - run: mix format --check-formatted
       - run: mix test

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/redix/stream/consumer.ex
+++ b/lib/redix/stream/consumer.ex
@@ -3,17 +3,18 @@ defmodule Redix.Stream.Consumer do
   """
 
   @type state :: %{
-    redix: Redix.Stream.redix,
-    stream: Redix.Stream.t,
-    handler: function() | mfa()
-  }
+          redix: Redix.Stream.redix(),
+          stream: Redix.Stream.t(),
+          handler: function() | mfa()
+        }
 
   @default_timeout 0
 
   @doc """
   Starts a new GenServer of `Redix.Stream.Consumer`.
   """
-  @spec start_link(Redix.Stream.redix, Redix.Stream.t, function() | mfa(), keyword()) :: Supervisor.Spec.spec
+  @spec start_link(Redix.Stream.redix(), Redix.Stream.t(), function() | mfa(), keyword()) ::
+          Supervisor.Spec.spec()
   def start_link(redix, stream, handler, opts \\ []) do
     GenServer.start_link(__MODULE__, {redix, stream, handler, opts})
   end
@@ -22,49 +23,55 @@ defmodule Redix.Stream.Consumer do
   Initializes a new `Redix.Stream.Consumer`, establishing a long-term
   stream with the given `redis` server.
   """
-  @spec init({Redix.Stream.redix, Redix.Stream.t, function() | mfa(), keyword}) :: {:ok, state}
+  @spec init({Redix.Stream.redix(), Redix.Stream.t(), function() | mfa(), keyword}) ::
+          {:ok, state}
   def init({redix, stream, handler, opts}) do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
     default_start_pos = Keyword.get(opts, :start_pos, "$")
     tracker = Keyword.get(opts, :tracker, nil)
 
     # If tracker specified, load our starting position
-    start_pos = if tracker do
-      case Redix.command!(redix, ["GET", "stream_tracker:#{tracker}"]) do
-        nil -> default_start_pos
-        pos -> pos
+    start_pos =
+      if tracker do
+        case Redix.command!(redix, ["GET", "stream_tracker:#{tracker}"]) do
+          nil -> default_start_pos
+          pos -> pos
+        end
+      else
+        default_start_pos
       end
-    else
-      default_start_pos
-    end
 
     stream_more_data(timeout, start_pos)
 
-    {:ok, %{
-      redix: redix,
-      stream: stream,
-      tracker: tracker,
-      handler: handler}}
+    {:ok, %{redix: redix, stream: stream, tracker: tracker, handler: handler}}
   end
 
   @doc """
   Handles a new message from a stream, dispatching it to the given handler.
   """
-  def handle_info({:stream_more_data, timeout, start_pos}, %{redix: redix, stream: stream, handler: handler, tracker: tracker}=state) do
-
+  def handle_info(
+        {:stream_more_data, timeout, start_pos},
+        %{redix: redix, stream: stream, handler: handler, tracker: tracker} = state
+      ) do
     # Wait for a number of messages to come in
-    {:ok, stream_results} = Redix.command(redix, ["XREAD", "BLOCK", timeout, "STREAMS", stream, start_pos], timeout: :infinity)
+    {:ok, stream_results} =
+      Redix.command(
+        redix,
+        ["XREAD", "BLOCK", timeout, "STREAMS", stream, start_pos],
+        timeout: :infinity
+      )
 
     # Process the results and get the next positions to consume from
     for stream_result <- stream_results do
       [^stream, items] = stream_result
 
-      {stream_items, next_pos} = Enum.reduce(items, {[], start_pos}, fn [id, kvs], {msgs, _next_pos} ->
-        {[{id, kvs}|msgs], id}
-      end)
+      {stream_items, next_pos} =
+        Enum.reduce(items, {[], start_pos}, fn [id, kvs], {msgs, _next_pos} ->
+          {[{id, kvs} | msgs], id}
+        end)
 
       # Process the items
-      for stream_item <- stream_items |> Enum.reverse do
+      for stream_item <- stream_items |> Enum.reverse() do
         call_handler(handler, stream, stream_item)
       end
 
@@ -80,21 +87,20 @@ defmodule Redix.Stream.Consumer do
     {:noreply, state}
   end
 
-  @spec call_handler(mfa(), Redix.Stream.t, any()) :: any()
+  @spec call_handler(mfa(), Redix.Stream.t(), any()) :: any()
   defp call_handler({module, function, args}, stream, msg) do
     apply(module, function, args ++ [stream, msg])
   end
 
-  @spec call_handler(function(), Redix.Stream.t, any()) :: any()
+  @spec call_handler(function(), Redix.Stream.t(), any()) :: any()
   defp call_handler(fun, stream, msg) do
     fun.(stream, msg)
   end
 
-  @spec stream_more_data(integer(), String.t) :: :ok
+  @spec stream_more_data(integer(), String.t()) :: :ok
   defp stream_more_data(timeout, next_pos) do
     Process.send_after(self(), {:stream_more_data, timeout, next_pos}, 0)
 
     :ok
   end
-
 end

--- a/lib/stream.ex
+++ b/lib/stream.ex
@@ -4,7 +4,7 @@ defmodule Redix.Stream do
   """
 
   @type redix :: pid() | atom()
-  @type t :: String.t
+  @type t :: String.t()
 
   @doc """
   Produces a new single message in a Redis stream.
@@ -13,7 +13,7 @@ defmodule Redix.Stream do
 
       iex> Redix.Stream.produce(:redix, "topic", "temperature", 55)
   """
-  @spec produce(redix, t, String.t, any()) :: {:ok, String.t} | {:error, any()}
+  @spec produce(redix, t, String.t(), any()) :: {:ok, String.t()} | {:error, any()}
   def produce(redix, stream, key, value) do
     case Redix.command(redix, ["XADD", stream, "*", key, value]) do
       {:ok, id} when is_binary(id) -> {:ok, id}
@@ -33,7 +33,7 @@ defmodule Redix.Stream do
 
       iex> Redix.Stream.consumer(:redix, "topic", {Module, :function, [:arg1, :arg2]}, tracker: "my_stream_tracker")
   """
-  @spec consumer(redix, t, function() | mfa(), keyword()) :: Supervisor.Spec.spec
+  @spec consumer(redix, t, function() | mfa(), keyword()) :: Supervisor.Spec.spec()
   def consumer(redix, stream, callback, opts \\ []) do
     Supervisor.Spec.worker(Redix.Stream.Consumer, [redix, stream, callback, opts])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,7 @@ defmodule RedixStream.Mixfile do
         links: %{"GitHub" => "https://github.com/hayesgm/redix_stream"}
       ],
       elixir: "~> 1.5",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
   end
@@ -29,7 +29,7 @@ defmodule RedixStream.Mixfile do
     [
       {:redix, "~> 0.6.1"},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false},
-      {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
+      {:dialyxir, "~> 0.5", only: [:dev], runtime: false}
     ]
   end
 end

--- a/test/redix/stream/consumer_test.exs
+++ b/test/redix/stream/consumer_test.exs
@@ -10,13 +10,15 @@ defmodule Redix.Stream.ConsumerTest do
     {:ok, redix_2} = Redix.start_link()
     pid = self()
 
-    {:ok, _pid} = Redix.Stream.Consumer.start_link(
-      redix_1,
-      @test_stream,
-      fn stream, {id, values} -> send(pid, {:streamed, stream, id, values}) end
-    )
+    {:ok, _pid} =
+      Redix.Stream.Consumer.start_link(
+        redix_1,
+        @test_stream,
+        fn stream, {id, values} -> send(pid, {:streamed, stream, id, values}) end
+      )
 
-    :timer.sleep(500) # allow consumer time to connect
+    # allow consumer time to connect
+    :timer.sleep(500)
 
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_1", "value_1")
 
@@ -29,13 +31,15 @@ defmodule Redix.Stream.ConsumerTest do
     {:ok, redix_2} = Redix.start_link()
     pid = self()
 
-    {:ok, _pid} = Redix.Stream.Consumer.start_link(
-      redix_1,
-      @test_stream,
-      fn stream, {id, values} -> send(pid, {:streamed, stream, id, values}) end
-    )
+    {:ok, _pid} =
+      Redix.Stream.Consumer.start_link(
+        redix_1,
+        @test_stream,
+        fn stream, {id, values} -> send(pid, {:streamed, stream, id, values}) end
+      )
 
-    :timer.sleep(500) # allow consumer time to connect
+    # allow consumer time to connect
+    :timer.sleep(500)
 
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_1", "value_1")
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_2", "value_2")
@@ -53,18 +57,21 @@ defmodule Redix.Stream.ConsumerTest do
     {:ok, redix_2} = Redix.start_link()
     pid = self()
 
-    {:ok, _pid} = Redix.Stream.Consumer.start_link(
-      redix_1,
-      @test_stream,
-      fn stream, {id, values} ->
-        :timer.sleep(100) # this runs in the consumer and blocks
-                          # further processing.
+    {:ok, _pid} =
+      Redix.Stream.Consumer.start_link(
+        redix_1,
+        @test_stream,
+        fn stream, {id, values} ->
+          # this runs in the consumer and blocks
+          :timer.sleep(100)
+          # further processing.
 
-        send(pid, {:streamed, stream, id, values})
-      end
-    )
+          send(pid, {:streamed, stream, id, values})
+        end
+      )
 
-    :timer.sleep(500) # allow consumer time to connect
+    # allow consumer time to connect
+    :timer.sleep(500)
 
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_1", "value_1")
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_2", "value_2")
@@ -82,15 +89,17 @@ defmodule Redix.Stream.ConsumerTest do
     {:ok, redix_3} = Redix.start_link()
     pid = self()
 
-    {:ok, consumer_pid} = Redix.Stream.Consumer.start_link(
-      redix_1,
-      @test_stream,
-      fn stream, {id, values} ->
-        send(pid, {:streamed, stream, id, values})
-      end
-    )
+    {:ok, consumer_pid} =
+      Redix.Stream.Consumer.start_link(
+        redix_1,
+        @test_stream,
+        fn stream, {id, values} ->
+          send(pid, {:streamed, stream, id, values})
+        end
+      )
 
-    :timer.sleep(500) # allow consumer time to connect
+    # allow consumer time to connect
+    :timer.sleep(500)
 
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_1", "value_1")
 
@@ -99,15 +108,17 @@ defmodule Redix.Stream.ConsumerTest do
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_2", "value_2")
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_3", "value_3")
 
-    {:ok, _consumer_2_pid} = Redix.Stream.Consumer.start_link(
-      redix_3,
-      @test_stream,
-      fn stream, {id, values} ->
-        send(pid, {:streamed_2, stream, id, values})
-      end
-    )
+    {:ok, _consumer_2_pid} =
+      Redix.Stream.Consumer.start_link(
+        redix_3,
+        @test_stream,
+        fn stream, {id, values} ->
+          send(pid, {:streamed_2, stream, id, values})
+        end
+      )
 
-    :timer.sleep(500) # allow consumer time to connect
+    # allow consumer time to connect
+    :timer.sleep(500)
 
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_4", "value_4")
 
@@ -124,16 +135,18 @@ defmodule Redix.Stream.ConsumerTest do
     {:ok, redix_3} = Redix.start_link()
     pid = self()
 
-    {:ok, consumer_pid} = Redix.Stream.Consumer.start_link(
-      redix_1,
-      @test_stream,
-      fn stream, {id, values} ->
-        send(pid, {:streamed, stream, id, values})
-      end,
-      tracker: "my_stream_tracker"
-    )
+    {:ok, consumer_pid} =
+      Redix.Stream.Consumer.start_link(
+        redix_1,
+        @test_stream,
+        fn stream, {id, values} ->
+          send(pid, {:streamed, stream, id, values})
+        end,
+        tracker: "my_stream_tracker"
+      )
 
-    :timer.sleep(500) # allow consumer time to connect
+    # allow consumer time to connect
+    :timer.sleep(500)
 
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_1", "value_1")
 
@@ -142,16 +155,18 @@ defmodule Redix.Stream.ConsumerTest do
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_2", "value_2")
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_3", "value_3")
 
-    {:ok, _consumer_2_pid} = Redix.Stream.Consumer.start_link(
-      redix_3,
-      @test_stream,
-      fn stream, {id, values} ->
-        send(pid, {:streamed_2, stream, id, values})
-      end,
-      tracker: "my_stream_tracker"
-    )
+    {:ok, _consumer_2_pid} =
+      Redix.Stream.Consumer.start_link(
+        redix_3,
+        @test_stream,
+        fn stream, {id, values} ->
+          send(pid, {:streamed_2, stream, id, values})
+        end,
+        tracker: "my_stream_tracker"
+      )
 
-    :timer.sleep(500) # allow consumer time to connect
+    # allow consumer time to connect
+    :timer.sleep(500)
 
     {:ok, _msg_id} = Redix.Stream.produce(redix_2, @test_stream, "key_4", "value_4")
 

--- a/test/stream_test.exs
+++ b/test/stream_test.exs
@@ -15,34 +15,58 @@ defmodule Redix.StreamTest do
       spec = Redix.Stream.consumer(:redix, "topic", fn msg -> msg end)
 
       assert {
-        Redix.Stream.Consumer,
-        {Redix.Stream.Consumer, :start_link, [:redix, "topic", _fn, []]},
-        :permanent, 5000, :worker, [Redix.Stream.Consumer]
-      } = spec
+               Redix.Stream.Consumer,
+               {Redix.Stream.Consumer, :start_link, [:redix, "topic", _fn, []]},
+               :permanent,
+               5000,
+               :worker,
+               [Redix.Stream.Consumer]
+             } = spec
     end
 
     test "it should produce a spec with given multiple streams and an MFA" do
       spec = Redix.Stream.consumer(:redix, "topic", {Module, :function, [:arg1, :arg2]})
 
       assert {
-        Redix.Stream.Consumer,
-        {
-          Redix.Stream.Consumer, :start_link, [:redix, "topic", {Module, :function, [:arg1, :arg2]}, []]
-        },
-        :permanent, 5000, :worker, [Redix.Stream.Consumer]
-      } = spec
+               Redix.Stream.Consumer,
+               {
+                 Redix.Stream.Consumer,
+                 :start_link,
+                 [:redix, "topic", {Module, :function, [:arg1, :arg2]}, []]
+               },
+               :permanent,
+               5000,
+               :worker,
+               [Redix.Stream.Consumer]
+             } = spec
     end
 
     test "it should produce a spec with given multiple streams and an MFA and opts" do
-      spec = Redix.Stream.consumer(:redix, "topic", {Module, :function, [:arg1, :arg2]}, group: "my_consumer_group")
+      spec =
+        Redix.Stream.consumer(
+          :redix,
+          "topic",
+          {Module, :function, [:arg1, :arg2]},
+          group: "my_consumer_group"
+        )
 
       assert {
-        Redix.Stream.Consumer,
-        {
-          Redix.Stream.Consumer, :start_link, [:redix, "topic", {Module, :function, [:arg1, :arg2]}, [group: "my_consumer_group"]]
-        },
-        :permanent, 5000, :worker, [Redix.Stream.Consumer]
-      } = spec
+               Redix.Stream.Consumer,
+               {
+                 Redix.Stream.Consumer,
+                 :start_link,
+                 [
+                   :redix,
+                   "topic",
+                   {Module, :function, [:arg1, :arg2]},
+                   [group: "my_consumer_group"]
+                 ]
+               },
+               :permanent,
+               5000,
+               :worker,
+               [Redix.Stream.Consumer]
+             } = spec
     end
   end
 end


### PR DESCRIPTION
Hi there,

I was hoping to contribute consumer-group support as that is now supported in the 5.0 RCs. As a precursor to that, I was hoping it would be ok to format the code with `mix format` to keep things consistent between contributors.

Thanks!