### PR TITLE
Significant Improvements to API and Consumer Groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.0
+ * Add a supervisor for each consumer
+ * Handle shutdown of a consumer gracefully
 # 0.1.6/7
  * Fix typespecs around mfa() and handler()
 # 0.1.5

--- a/README.md
+++ b/README.md
@@ -99,17 +99,23 @@ def MyApp.Application do
 
 Each consumer in the consumer group will process messages in parallel with other consumers, but each group will only consume each message one time. You can have multiple consumer groups for a given stream.
 
-## Consumer Options
+## Consumer Spec Options
 
-The following options can be passed in to `consumer_spec` when defining a consumer:
+Each consumer will have a single supervisor to monitor that consumer. This allows the supervisor to restart the consumer for temporary issues.
 
+The following options can be passed in to `consumer_spec` when defining a consumer and supervisor:
+
+* `sup_id` - The id to register the supervisor process as (default: `Redix.Stream.ConsumerSup`)
+* `sup_restart` - The restart-type for the supervisor (`:transient`, `:temporary` or `:permanent`) (default: `:permanent`)
+* `sup_name` - The name to register the supervisor as (default: same as sup_id)
+* `sup_timeout` - The shutdown strategy (or timeout) for the supervisor.
 * `id` - The id to register the consumer process as (default: `Redix.Stream.Consumer`)
-* `timeout` - Timeout to wait for new messages in the stream before failing, 0 implies block forever (default: 0)
-* `group_name` - Consumer group for this consumer. We will create the group if it does not already exist (default: nil)
-* `consumer_name` - Unique name for this consumer. These names should be persistent per work since each consumer will claim messages that need to be processed. (default: nil)
-* `create_not_exists` - We will create the stream if it does not already exist (default: true)
-* `process_pending` - For a consumer in a consumer group, should we process pending messages (ones we claimed but did not successfully process) before processing new messages? (default: true)
-* `raise_errors` - If we fail to process a message because a handler returns an `{:error, error}` tuple, should we raise an error to fail the processor versus continue with an unacknowledged message? (default: true)
+* `timeout` - Timeout to wait for new messages in the stream before failing, 0 implies block forever (default: `0`)
+* `group_name` - Consumer group for this consumer. We will create the group if it does not already exist (default: `nil`)
+* `consumer_name` - Unique name for this consumer. These names should be persistent per work since each consumer will claim messages that need to be processed. (default: `nil`)
+* `create_not_exists` - We will create the stream if it does not already exist (default: `true`)
+* `process_pending` - For a consumer in a consumer group, should we process pending messages (ones we claimed but did not successfully process) before processing new messages? (default: `true`)
+* `raise_errors` - If we fail to process a message because a handler returns an `{:error, error}` tuple, should we raise an error to fail the processor versus continue with an unacknowledged message? (default: `true`)
 
 ## Contributing
 

--- a/lib/redix/stream/consumer.ex
+++ b/lib/redix/stream/consumer.ex
@@ -1,5 +1,6 @@
 defmodule Redix.Stream.Consumer do
   @moduledoc """
+  ABC
   """
 
   @type group_name :: String.t()
@@ -11,10 +12,27 @@ defmodule Redix.Stream.Consumer do
           stream: Redix.Stream.t(),
           group_name: group_name(),
           consumer_name: consumer_name(),
-          handler: function() | Redix.Stream.handler()
+          handler: function() | Redix.Stream.handler(),
+          process_pending: boolean(),
+          raise_errors: boolean()
         }
 
   @default_timeout 0
+
+  @doc """
+  Returns child specification when used with a supervisor.
+  """
+  @spec child_spec(
+          {Redix.Stream.redix(), Redix.Stream.t(), function() | Redix.Stream.handler(), keyword()}
+        ) :: Supervisor.child_spec()
+  def child_spec({redix, stream, handler, opts}) do
+    {id, opts_without_id} = Keyword.pop(opts, :id, __MODULE__)
+
+    %{
+      id: id,
+      start: {__MODULE__, :start_link, [redix, stream, handler, opts_without_id]}
+    }
+  end
 
   @doc """
   Starts a new GenServer of `Redix.Stream.Consumer`.
@@ -30,8 +48,8 @@ defmodule Redix.Stream.Consumer do
   end
 
   @doc """
-  Initializes a new `Redix.Stream.Consumer`, establishing a long-term
-  stream with the given `redis` server.
+  Initializes a new `Redix.Stream.Consumer`, establishing a long-term stream
+  with the given `redis` server.
   """
   @spec init(
           {Redix.Stream.redix(), Redix.Stream.t(), function() | Redix.Stream.handler(), keyword}
@@ -41,31 +59,50 @@ defmodule Redix.Stream.Consumer do
     group_name = Keyword.get(opts, :group_name)
     consumer_name = Keyword.get(opts, :consumer_name)
     consumer_group_command_connection = Keyword.get(opts, :consumer_group_command_connection)
+    create_not_exists = Keyword.get(opts, :create_not_exists, true)
+    process_pending = Keyword.get(opts, :process_pending, true)
+    raise_errors = Keyword.get(opts, :raise_errors, true)
 
     default_start_pos =
       case group_name do
-        nil -> "$"
-        _ -> ">"
+        nil -> :end_of_stream
+        _ -> :last_known_message
       end
 
-    start_pos = Keyword.get(opts, :start_pos, default_start_pos)
+    start_pos_given = Keyword.get(opts, :start_pos, default_start_pos)
+
+    start_pos =
+      case {group_name, process_pending, start_pos_given} do
+        {nil, _, :start_of_stream} -> "0"
+        {nil, _, :end_of_stream} -> "$"
+        {_, true, _} -> "0"
+        {_, false, :start_of_stream} -> "0"
+        {_, false, :end_of_stream} -> "$"
+        {_, false, :last_known_message} -> "$"
+        {_, false, other} -> other
+      end
 
     if consumer_name do
-      try do
-        start_pos =
-          case start_pos do
-            "$" -> "$"
-            ">" -> "$"
-            other -> other
+      case Redix.command(redix, ["XGROUP", "CREATE", stream, group_name, start_pos]) do
+        {:error, error = %Redix.Error{message: "ERR no such key"}} ->
+          if create_not_exists do
+            {:ok, _} = Redix.command(redix, ["XADD", stream, "*", "", ""])
+
+            # Recurse without create_not_exists flag set
+            init({redix, stream, handler, Keyword.put(opts, :create_not_exists, false)})
+          else
+            raise error
           end
 
-        Redix.command(redix, ["XGROUP", "CREATE", stream, group_name, start_pos])
-      rescue
-        e in Redix.Error ->
-          case e.message do
-            "BUSYGROUP Consumer Group name already exists" -> nil
-            _ -> raise e
-          end
+        {:error, %Redix.Error{message: "BUSYGROUP Consumer Group name already exists"}} ->
+          # This is fine, just means the group already exists
+          :ok
+
+        {:error, error} ->
+          raise error
+
+        {:ok, _} ->
+          :ok
       end
     end
 
@@ -78,13 +115,16 @@ defmodule Redix.Stream.Consumer do
        stream: stream,
        group_name: group_name,
        consumer_name: consumer_name,
-       handler: handler
+       handler: handler,
+       process_pending: process_pending,
+       raise_errors: raise_errors
      }}
   end
 
   @doc """
   Handles a new message from a stream, dispatching it to the given handler.
   """
+  # When we have a consumer group
   def handle_info(
         {:stream_more_data, timeout, start_pos},
         %{
@@ -93,7 +133,9 @@ defmodule Redix.Stream.Consumer do
           stream: stream,
           group_name: group_name,
           consumer_name: consumer_name,
-          handler: handler
+          handler: handler,
+          process_pending: process_pending,
+          raise_errors: raise_errors
         } = state
       )
       when not is_nil(group_name) and not is_nil(consumer_name) and
@@ -116,38 +158,53 @@ defmodule Redix.Stream.Consumer do
         timeout: :infinity
       )
 
-    # Process the results and get the next positions to consume from
-    for [^stream, items] <- stream_results do
-      {stream_items, next_pos} = stream_items_to_tuples(items, start_pos)
+    if process_pending && stream_results == [[stream, []]] do
+      # If we ran out of results, let's switch from processing
+      # pending to most recent.
+      stream_more_data(timeout, ">")
 
-      # Process the items
-      for stream_item = {id, _} <- stream_items |> Enum.reverse() do
-        case call_handler(handler, stream, stream_item) do
-          :ok ->
-            {:ok, _} =
-              Redix.command(consumer_group_command_connection, ["XACK", stream, group_name, id])
+      {:noreply, %{state | process_pending: false}}
+    else
+      # Process the results and get the next positions to consume from
+      for [^stream, items] <- stream_results do
+        {stream_items, next_pos} = stream_items_to_tuples(items, start_pos)
 
-          _ ->
-            nil
+        # Process the items
+        for {id, map} <- Enum.reverse(stream_items) do
+          case call_handler(handler, stream, id, map) do
+            :ok ->
+              # TODO: Should we allow asynchronous ack?
+
+              {:ok, _} =
+                Redix.command(consumer_group_command_connection, [
+                  "XACK",
+                  stream,
+                  group_name,
+                  id
+                ])
+
+            {:error, error} ->
+              if raise_errors do
+                raise "#{__MODULE__} Error processing #{id}: #{error}\n\nvalues:\n#{inspect(map)}"
+              end
+          end
         end
+
+        next_pos =
+          case start_pos do
+            ">" -> ">"
+            _ -> next_pos
+          end
+
+        # And stream more data...
+        stream_more_data(timeout, next_pos)
       end
 
-      next_pos =
-        case start_pos do
-          ">" -> ">"
-          _ -> next_pos
-        end
-
-      # And stream more data...
-      stream_more_data(timeout, next_pos)
+      {:noreply, state}
     end
-
-    {:noreply, state}
   end
 
-  @doc """
-  Handles a new message from a stream, dispatching it to the given handler.
-  """
+  # Without a consumer group
   def handle_info(
         {:stream_more_data, timeout, start_pos},
         %{
@@ -169,8 +226,8 @@ defmodule Redix.Stream.Consumer do
       {stream_items, next_pos} = stream_items_to_tuples(items, start_pos)
 
       # Process the items
-      for stream_item <- stream_items |> Enum.reverse() do
-        call_handler(handler, stream, stream_item)
+      for {id, map} <- Enum.reverse(stream_items) do
+        call_handler(handler, stream, id, map)
       end
 
       # And stream more data...
@@ -180,21 +237,34 @@ defmodule Redix.Stream.Consumer do
     {:noreply, state}
   end
 
-  @spec call_handler(Redix.Stream.handler(), Redix.Stream.t(), any()) :: any()
-  defp call_handler({module, function, args}, stream, msg) do
-    apply(module, function, args ++ [stream, msg])
+  @spec call_handler(Redix.Stream.handler(), Redix.Stream.t(), String.t(), %{
+          String.t() => String.t()
+        }) :: any()
+  # Handle sentinel
+  defp call_handler(_handler, _stream, _id, %{"" => ""}), do: :ok
+
+  defp call_handler({module, function, args}, stream, id, map) do
+    apply(module, function, args ++ [stream, id, map])
   end
 
-  @spec call_handler(function(), Redix.Stream.t(), any()) :: any()
-  defp call_handler(fun, stream, msg) do
-    fun.(stream, msg)
+  @spec call_handler(function(), Redix.Stream.t(), String.t(), %{
+          String.t() => String.t()
+        }) :: any()
+  defp call_handler(fun, stream, id, map) do
+    fun.(stream, id, map)
   end
 
   @spec stream_items_to_tuples(list(list(String.t() | list(String.t()))), String.t()) ::
           {list({String.t(), list(String.t())}), String.t()}
   defp stream_items_to_tuples(items, start_pos) do
-    Enum.reduce(items, {[], start_pos}, fn [id, kvs], {msgs, _next_pos} ->
-      {[{id, kvs} | msgs], id}
+    Enum.reduce(items, {[], start_pos}, fn [id, key_values], {msgs, _next_pos} ->
+      map =
+        key_values
+        |> Enum.chunk_every(2)
+        |> Enum.map(fn [a, b] -> {a, b} end)
+        |> Enum.into(%{})
+
+      {[{id, map} | msgs], id}
     end)
   end
 

--- a/lib/redix/stream/consumer_sup.ex
+++ b/lib/redix/stream/consumer_sup.ex
@@ -1,0 +1,41 @@
+defmodule Redix.Stream.ConsumerSup do
+  @moduledoc """
+  Supervisor which attempts to restart a failed consumer.
+
+  Generally, you should start this supervisor as transient,
+  since a failure will be unrecoverable beyond this point.
+  """
+  use Supervisor
+
+  alias Redix.Stream.Consumer
+
+  def child_spec([redix, stream, handler, opts]) do
+    {sup_id, opts_2} = Keyword.pop(opts, :sup_id, __MODULE__)
+    {restart, opts_3} = Keyword.pop(opts_2, :sup_restart, :permanent)
+    opts_4 = Keyword.put(opts_3, :sup_name, sup_id)
+
+    %{
+      id: sup_id,
+      start: {__MODULE__, :start_link, [redix, stream, handler, opts_4]},
+      type: :supervisor,
+      restart: restart
+    }
+  end
+
+  def start_link(redix, stream, handler, opts) do
+    {sup_name, rest_opts} = Keyword.pop(opts, :sup_name, __MODULE__)
+
+    Supervisor.start_link(__MODULE__, {redix, stream, handler, rest_opts}, name: sup_name)
+  end
+
+  @impl true
+  def init({redix, stream, handler, opts}) do
+    {shutdown, consumer_opts} = Keyword.pop(opts, :sup_timeout, 5000)
+
+    children = [
+      {Consumer, {redix, stream, handler, consumer_opts}}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one, shutdown: shutdown)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RedixStream.Mixfile do
   def project do
     [
       app: :redix_stream,
-      version: "0.1.7",
+      version: "0.2.0",
       description: "Redis Stream Processor in Elxir, built on redix",
       package: [
         maintainers: ["Geoffrey Hayes"],
@@ -27,7 +27,7 @@ defmodule RedixStream.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:redix, "~> 0.8.2"},
+      {:redix, "~> 0.9.0"},
       {:ex_doc, "~> 0.19", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0.0-rc.3", only: [:dev], runtime: false}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -6,5 +6,5 @@
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [:mix], [], "hexpm"},
-  "redix": {:hex, :redix, "0.8.2", "c25158f905bcf8842e9a11411d65b9257ac70057c4330521d1a4d2a44b4f7ecf", [:mix], [], "hexpm"},
+  "redix": {:hex, :redix, "0.9.0", "c631c921354587e054bf1e2a6b7d0120d617352fc42b624b9ca79ea484d0326c", [:mix], [], "hexpm"},
 }

--- a/test/redix/stream/consumer_sup_test.exs
+++ b/test/redix/stream/consumer_sup_test.exs
@@ -1,0 +1,4 @@
+defmodule Redix.Stream.ConsumerSupTest do
+  use ExUnit.Case
+  doctest Redix.Stream.ConsumerSup
+end

--- a/test/redix/stream_test.exs
+++ b/test/redix/stream_test.exs
@@ -23,8 +23,12 @@ defmodule Redix.StreamTest do
       spec = Redix.Stream.consumer_spec(:redix, "topic", fn msg -> msg end)
 
       assert %{
-               id: Redix.Stream.Consumer,
-               start: {Redix.Stream.Consumer, :start_link, [:redix, "topic", _fn, []]}
+               id: Redix.Stream.ConsumerSup,
+               start:
+                 {Redix.Stream.ConsumerSup, :start_link,
+                  [:redix, "topic", _fn, [sup_name: Redix.Stream.ConsumerSup]]},
+               type: :supervisor,
+               restart: :permanent
              } = spec
     end
 
@@ -32,13 +36,20 @@ defmodule Redix.StreamTest do
       spec = Redix.Stream.consumer_spec(:redix, "topic", {Module, :function, [:arg1, :arg2]})
 
       assert %{
-               id: Redix.Stream.Consumer,
+               id: Redix.Stream.ConsumerSup,
                start: {
-                 Redix.Stream.Consumer,
+                 Redix.Stream.ConsumerSup,
                  :start_link,
-                 [:redix, "topic", {Module, :function, [:arg1, :arg2]}, []]
-               }
-             } = spec
+                 [
+                   :redix,
+                   "topic",
+                   {Module, :function, [:arg1, :arg2]},
+                   [sup_name: Redix.Stream.ConsumerSup]
+                 ]
+               },
+               type: :supervisor,
+               restart: :permanent
+             } == spec
     end
 
     test "it should produce a spec with given multiple streams and an MFA and opts" do
@@ -51,17 +62,22 @@ defmodule Redix.StreamTest do
         )
 
       assert %{
-               id: Redix.Stream.Consumer,
+               id: Redix.Stream.ConsumerSup,
                start: {
-                 Redix.Stream.Consumer,
+                 Redix.Stream.ConsumerSup,
                  :start_link,
                  [
                    :redix,
                    "topic",
                    {Module, :function, [:arg1, :arg2]},
-                   [group: "my_consumer_group"]
+                   [
+                     sup_name: Redix.Stream.ConsumerSup,
+                     group: "my_consumer_group"
+                   ]
                  ]
-               }
+               },
+               type: :supervisor,
+               restart: :permanent
              } = spec
     end
   end

--- a/test/redix/stream_test.exs
+++ b/test/redix/stream_test.exs
@@ -1,10 +1,18 @@
 defmodule Redix.StreamTest do
   use ExUnit.Case
+  doctest Redix.Stream
+
+  setup_all do
+    {:ok, pid} = Redix.start_link()
+    Process.register(pid, :redix)
+
+    :ok
+  end
 
   describe "produce/4" do
     test "it produces a new id" do
       {:ok, redix} = Redix.start_link()
-      {:ok, msg_id} = Redix.Stream.produce(redix, "topic", "temperature", 55)
+      {:ok, msg_id} = Redix.Stream.produce(redix, "topic", %{"temperature" => 55})
 
       assert Regex.match?(~r/\d+-\d+$/, msg_id)
     end
@@ -12,7 +20,7 @@ defmodule Redix.StreamTest do
 
   describe "consumer/3" do
     test "it should produce a spec with given a single stream and simple function" do
-      spec = Redix.Stream.consumer(:redix, "topic", fn msg -> msg end)
+      spec = Redix.Stream.consumer_spec(:redix, "topic", fn msg -> msg end)
 
       assert %{
                id: Redix.Stream.Consumer,
@@ -21,7 +29,7 @@ defmodule Redix.StreamTest do
     end
 
     test "it should produce a spec with given multiple streams and an MFA" do
-      spec = Redix.Stream.consumer(:redix, "topic", {Module, :function, [:arg1, :arg2]})
+      spec = Redix.Stream.consumer_spec(:redix, "topic", {Module, :function, [:arg1, :arg2]})
 
       assert %{
                id: Redix.Stream.Consumer,
@@ -35,7 +43,7 @@ defmodule Redix.StreamTest do
 
     test "it should produce a spec with given multiple streams and an MFA and opts" do
       spec =
-        Redix.Stream.consumer(
+        Redix.Stream.consumer_spec(
           :redix,
           "topic",
           {Module, :function, [:arg1, :arg2]},


### PR DESCRIPTION
This pr is primarily concerned with improving consumer groups to better allow for exactly-once processing. We make sure that each consumer group acknowleges successfully processed messages and allow consumer groups to process claimed but unprocessed messages on start-up.

Additionally, we clean up our APIs so that handlers can use a simple `stream, id, %{k => v}` type handlers, which makes more sense with expectations.

We also upgrade to the latest version of redix and use proper `child_spec` for consumer specifications, now.