### PR TITLE
Use MKSTREAM instead of wrapping failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.2.1
+ * Use new MKSTREAM on Redis consumer group instead of wrapping failure
 # 0.2.0
  * Add a supervisor for each consumer
  * Handle shutdown of a consumer gracefully

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RedixStream.Mixfile do
   def project do
     [
       app: :redix_stream,
-      version: "0.2.0",
+      version: "0.2.1",
       description: "Redis Stream Processor in Elxir, built on redix",
       package: [
         maintainers: ["Geoffrey Hayes"],


### PR DESCRIPTION
It's probably a good idea to hold off on merging this, since it's only available on bleeding edge Redis. I'm also not quite sure how to handle the version bump, since it doesn't change the API, but it does require a new version of an implicit dep.